### PR TITLE
Tweaking IAM group permissions for Bootstrap

### DIFF
--- a/bootstrap/iam.tf
+++ b/bootstrap/iam.tf
@@ -6,10 +6,13 @@ locals {
       member = "group:${var.gcp_trainer_group}"
       roles = [
         "roles/compute.admin",
+        "roles/compute.networkAdmin",
         "roles/dns.admin",
         "roles/iap.tunnelResourceAccessor",
         "roles/container.admin",
-        "roles/iam.serviceAccountAdmin"
+        "roles/iam.serviceAccountAdmin",
+        "roles/iam.serviceAccountUser",
+        "roles/serviceusage.serviceUsageAdmin"
       ]
     }
   ]


### PR DESCRIPTION
This pull request includes changes to the IAM roles configuration in the `bootstrap/iam.tf` file to enhance permissions for the GCP trainer group. The most important change is the addition of new roles to the `roles` list.

IAM roles configuration updates:

* [`bootstrap/iam.tf`](diffhunk://#diff-ebaf7dd2a5ca7503cda976c8c02b80bb10bbadc8a19b8ff8bf9883b58ed54cf3R9-R15): Added `roles/compute.networkAdmin`, `roles/iam.serviceAccountUser`, and `roles/serviceusage.serviceUsageAdmin` to the `roles` list.