### PR TITLE
Altering resources and DNS to those of Lab at NOS

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -8,7 +8,7 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = "~> 6.15"
+      version = "~> 6.23"
     }
 
     kubectl = {

--- a/terraform.tfvars
+++ b/terraform.tfvars
@@ -1,5 +1,5 @@
 # obrigatório preencher
 #project_id               = ""
 user_prefix              = ""
-dns_master_zone_name     = "dns-master-zone"
-dns_admin_serviceaccount = "dns-admin@ten21-terraforming-p-154457.iam.gserviceaccount.com"
+dns_master_zone_name     = "dns-lab-01-public"
+dns_admin_serviceaccount = "sa-gke-dns@tf-gke-lab-01-np-000001.iam.gserviceaccount.com"

--- a/tutorial.md
+++ b/tutorial.md
@@ -17,7 +17,7 @@
 Certifica-te que tens a `google-cloud-shell` devidamente autorizada correndo este comando:
 
 ```bash
-gcloud config set project ten21-terraforming-p-154457 && gcloud config set accessibility/screen_reader false
+gcloud config set project tf-gke-lab-01-np-000001 && gcloud config set accessibility/screen_reader false
 ```
 
 De seguida, clica no botão **Start** para começares.

--- a/variables.tf
+++ b/variables.tf
@@ -19,13 +19,13 @@ variable "gke_location" {
 variable "dns_admin_serviceaccount" {
   description = "represents the service account that will be used to manage dns records"
   type        = string
-  default     = "dns-admin"
+  default     = "sa-gke-dns"
 }
 
 variable "dns_master_zone_name" {
   description = "The DNS master zone name for creating NS records."
   type        = string
-  default     = "dns-master-zone"
+  default     = "dns-lab-01-public"
 }
 
 variable "user_prefix" {


### PR DESCRIPTION
This pull request includes updates to several Terraform configuration files and a tutorial document to reflect changes in DNS settings and project identifiers. The most important changes include updating the required provider version, modifying DNS-related variables, and adjusting project IDs in the tutorial.

Terraform configuration updates:

* [`main.tf`](diffhunk://#diff-dc46acf24afd63ef8c556b77c126ccc6e578bc87e3aa09a931f33d9bf2532fbbL11-R11): Updated the `google` provider version from `~> 6.15` to `~> 6.23`.
* [`terraform.tfvars`](diffhunk://#diff-ea319dda5a35ac9ff7b01d3483e0ca0cf231d35d8d94a789bab86328aba7cb15L4-R5): Changed `dns_master_zone_name` to `dns-lab-01-public` and `dns_admin_serviceaccount` to `sa-gke-dns@tf-gke-lab-01-np-000001.iam.gserviceaccount.com`.
* [`variables.tf`](diffhunk://#diff-05b5a57c136b6ff596500bcbfdcff145ef6cddea2a0e86d184d9daa9a65a288eL22-R28): Updated default values for `dns_admin_serviceaccount` to `sa-gke-dns` and `dns_master_zone_name` to `dns-lab-01-public`.

Tutorial document update:

* [`tutorial.md`](diffhunk://#diff-54d121b9f8f94af2cb3fa5d2bbb327559d7145a8e5f45a98cc944cf204247cd8L20-R20): Modified the project ID in the `gcloud config set project` command to `tf-gke-lab-01-np-000001`.